### PR TITLE
Fix StatusBar white flicker when maximizing the form

### DIFF
--- a/src/uwin32widgetsetdark.pas
+++ b/src/uwin32widgetsetdark.pas
@@ -881,6 +881,25 @@ begin
     Exit;
   end;
 
+  if Msg = WM_ERASEBKGND then
+  begin
+    StatusBar:= TStatusBar(Info^.WinControl);
+    TWin32WSStatusBar.DoUpdate(StatusBar);
+    DC:= BeginPaint(Window, @ps);
+    LCanvas:= TCanvas.Create;
+    try
+      LCanvas.Handle:= DC;
+      LCanvas.Brush.Color:= SysColor[COLOR_MENUBAR];
+      LCanvas.FillRect(ps.rcPaint);
+    finally
+      LCanvas.Handle:= 0;
+      LCanvas.Free;
+    end;
+    EndPaint(Window, @ps);
+    Result:= 0;
+    Exit;
+  end;
+
   if Msg = WM_PAINT then
   begin
     StatusBar:= TStatusBar(Info^.WinControl);


### PR DESCRIPTION
When a form initially is loaded, and, later, each time when it is maximized, a StatusBar would appear painted in white for a short period of time. That's not severe, but not very nice either, and it is easy to fix:

