### PR TITLE
Fix metadarkstyledsgn.lpk: Missing search path for linux & mac compilation

### DIFF
--- a/metadarkstyledsgn.lpk
+++ b/metadarkstyledsgn.lpk
@@ -9,7 +9,7 @@
       <Version Value="11"/>
       <PathDelim Value="\"/>
       <SearchPaths>
-        <OtherUnitFiles Value="src\dsgn"/>
+        <OtherUnitFiles Value="src\dsgn;src"/>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
     </CompilerOptions>


### PR DESCRIPTION
Fixed a compilation error where `metadarkstyledsgn.lpk` appears to require `src\` in its searchPath when compiling a cross-platform project on linux/mac.

Error :
```
/var/build/submodules/metadarkstyle/./src/dsgn/registermetadarkstyledsgn.pas(10,21) Fatal: (10022) Can't find unit uDarkStyleSchemes used by registerMetaDarkStyleDSGN
```


- This is just for Lazarus cross compilation with win/lin/mac, even tho metadarkstyle is only used when compiling on windows.
- Lazarus doesn't support platform-specific project requirement. (wanting to require metadarkstyle only for windows compilation)