### PR TITLE
Fix dark theme lost after RDP reconnect and fix dsgn package build

### DIFF
--- a/metadarkstyle.lpk
+++ b/metadarkstyle.lpk
@@ -26,6 +26,14 @@
         <UnitName Value="uDarkStyleParams"/>
       </Item>
       <Item>
+        <Filename Value="src\udarkstyleschemes.pas"/>
+        <UnitName Value="uDarkStyleSchemes"/>
+      </Item>
+      <Item>
+        <Filename Value="src\udarkstyleschemesloader.pas"/>
+        <UnitName Value="uDarkStyleSchemesLoader"/>
+      </Item>
+      <Item>
         <Filename Value="src\udarkstyleschemesadditional.pas"/>
         <UnitName Value="uDarkStyleSchemesAdditional"/>
       </Item>

--- a/metadarkstyle.pas
+++ b/metadarkstyle.pas
@@ -8,8 +8,8 @@ unit MetaDarkStyle;
 interface
 
 uses
-  uMetaDarkStyle, uDarkStyleParams, uDarkStyleSchemesAdditional, 
-  LazarusPackageIntf;
+  uMetaDarkStyle, uDarkStyleParams, uDarkStyleSchemes, 
+  uDarkStyleSchemesLoader, uDarkStyleSchemesAdditional, LazarusPackageIntf;
 
 implementation
 

--- a/src/uwin32widgetsetdark.pas
+++ b/src/uwin32widgetsetdark.pas
@@ -685,6 +685,8 @@ function FormWndProc2(Window: HWnd; Msg: UInt; WParam: Windows.WParam;
 var
   DC: HDC;
   R: TRect;
+  Info: PWin32WindowInfo;
+  Form: TCustomForm;
 begin
   case Msg of
     WM_NCACTIVATE,
@@ -702,6 +704,24 @@ begin
       AllowDarkModeForWindow(Window, True);
       RefreshTitleBarThemeColor(Window);
       Result:= CallWindowProc(CustomFormWndProc, Window, Msg, wParam, lParam);
+    end;
+    WM_THEMECHANGED:
+    begin
+      Result:= CallWindowProc(CustomFormWndProc, Window, Msg, wParam, lParam);
+      AllowDarkModeForWindow(Window, True);
+      RefreshTitleBarThemeColor(Window);
+      Info:= GetWin32WindowInfo(Window);
+      if Assigned(Info) and Assigned(Info^.WinControl) and (Info^.WinControl is TCustomForm) then
+      begin
+        Form:= TCustomForm(Info^.WinControl);
+        if Assigned(Form.Menu) then
+        begin
+          Form.Menu.OwnerDraw:= True;
+          SetMenuBackground(GetMenu(Window));
+          Form.Menu.OwnerDraw:= False;
+        end;
+      end;
+      InvalidateRect(Window, nil, True);
     end
     else begin
       Result:= CallWindowProc(CustomFormWndProc, Window, Msg, wParam, lParam);


### PR DESCRIPTION
## Summary
- **RDP reconnect fix**: Handle `WM_THEMECHANGED` in `FormWndProc2` to re-apply `AllowDarkModeForWindow`, refresh title bar theme color, re-apply menu background brush, and invalidate the window. Without this, disconnecting and reconnecting an RDP session causes the menu bar and toolbar to revert to light theme, while dropdown menu text becomes dark on dark background (unreadable).
- **dsgn package build fix**: Register `uDarkStyleSchemes` and `uDarkStyleSchemesLoader` in `metadarkstyle.lpk` file list so that `metadarkstyledsgn` can resolve them via package dependency. This was broken since f53d298 which removed `src` from dsgn's `OtherUnitFiles` search path.

## Test plan
- [ ] Build `metadarkstyle.lpk` successfully
- [ ] Build `metadarkstyledsgn.lpk` successfully (previously failed with "Cannot find uDarkStyleSchemes")
- [ ] Install both packages, restart Lazarus IDE
- [ ] Connect via RDP, verify dark theme is active
- [ ] Disconnect RDP, reconnect, verify menu bar / toolbar / dropdown menus remain in dark theme