### PR TITLE
Add MetaDark header style for AnchorDocking dock headers

### DIFF
--- a/metadarkstyledsgn.lpk
+++ b/metadarkstyledsgn.lpk
@@ -28,6 +28,11 @@
         <AddToUsesPkgSection Value="False"/>
         <UnitName Value="registerMetaDarkStyleDSGN"/>
       </Item>
+      <Item>
+        <Filename Value="src\dsgn\umetadarkheaderstyle.pas"/>
+        <AddToUsesPkgSection Value="False"/>
+        <UnitName Value="uMetaDarkHeaderStyle"/>
+      </Item>
     </Files>
     <RequiredPkgs>
       <Item>
@@ -38,6 +43,9 @@
       </Item>
       <Item>
         <PackageName Value="MetaDarkStyle"/>
+      </Item>
+      <Item>
+        <PackageName Value="AnchorDocking"/>
       </Item>
       <Item>
         <PackageName Value="FCL"/>

--- a/src/dsgn/registermetadarkstyledsgn.pas
+++ b/src/dsgn/registermetadarkstyledsgn.pas
@@ -7,8 +7,10 @@ interface
 uses
   Classes, SysUtils,
   IDEOptionsIntf, IDEOptEditorIntf, LazIDEIntf, lazconf,
+  AnchorDocking,
   uDarkStyleParams, uDarkStyleSchemes, uMetaDarkStyle,
-  MetaDarkStyleDSGNOptionsFrame, MetaDarkStyleDSGNOptions;
+  MetaDarkStyleDSGNOptionsFrame, MetaDarkStyleDSGNOptions,
+  uMetaDarkHeaderStyle;
 
 var
   MetaDarkStyleOptionsID: integer = 1000;
@@ -28,6 +30,10 @@ begin
 end;
 
 procedure SetDarkStyle;
+{$IF DEFINED(MSWINDOWS)}
+var
+  Scheme: TDSColors;
+{$ENDIF}
 begin
  {$IF DEFINED(MSWINDOWS)}
   LoadLResources;
@@ -36,7 +42,12 @@ begin
   MetaDarkStyleDSGNOpt:=TMetaDarkStyleDSGNOptions.Create;
   MetaDarkStyleDSGNOpt.LoadSafe;
   PreferredAppMode:=AppModeOpt2PreferredAppMode(MetaDarkStyleDSGNOpt.AppMode);
-  ApplyMetaDarkStyle(GetScheme(MetaDarkStyleDSGNOpt.ColorScheme));
+  Scheme:=GetScheme(MetaDarkStyleDSGNOpt.ColorScheme);
+  ApplyMetaDarkStyle(Scheme);
+  if IsDarkModeEnabled and (DockMaster<>nil) then begin
+    RegisterMetaDarkHeaderStyle(Scheme);
+    DockMaster.HeaderStyle:=MetaDarkHeaderStyleName;
+  end;
  {$ENDIF}
 end;
 
@@ -45,6 +56,7 @@ begin
   MetaDarkStyleOptionsID:=RegisterIDEOptionsEditor(GroupEnvironment,
                                                    TDarkStyleDSGNOptionsFrame,
                                                    MetaDarkStyleOptionsID)^.Index;
+  HookIDERestoreWindows;
 end;
 
 initialization

--- a/src/dsgn/umetadarkheaderstyle.pas
+++ b/src/dsgn/umetadarkheaderstyle.pas
@@ -1,0 +1,110 @@
+{
+  MetaDarkStyle - AnchorDocking DockHeader dark style
+
+  Provides a custom 'MetaDark' header style for AnchorDocking so that the
+  Lazarus IDE dock headers (e.g. the caption bar on top of Object Inspector)
+  follow the metadarkstyle color scheme instead of the hard-coded clForm
+  background used by the built-in styles (Frame3D / Line / Lines / Points).
+
+  This unit lives in the design-time package (metadarkstyledsgn) because
+  AnchorDocking is an IDE-only dependency.
+}
+
+unit uMetaDarkHeaderStyle;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, Types, Graphics, LCLType,
+  AnchorDocking, LazIDEIntf,
+  uDarkStyleParams;
+
+const
+  MetaDarkHeaderStyleName = 'MetaDark';
+
+type
+  TMetaDarkHeaderHook = class
+    procedure OnIDERestoreWindows(Sender: TObject);
+  end;
+
+procedure RegisterMetaDarkHeaderStyle(const ASchemeColors: TDSColors);
+procedure HookIDERestoreWindows;
+procedure ForceApplyMetaDarkHeaderStyle;
+
+implementation
+
+var
+  HeaderColors: TDSColors;
+  Hook: TMetaDarkHeaderHook = nil;
+  HookInstalled: Boolean = False;
+
+procedure DrawMetaDarkHeader(Canvas: TCanvas; {%H-}Style: TADHeaderStyleDesc;
+  r: TRect; Horizontal: boolean; Focused: boolean);
+begin
+  Canvas.Brush.Color := HeaderColors.SysColor[COLOR_BTNFACE];
+  Canvas.Brush.Style := bsSolid;
+  Canvas.FillRect(r);
+
+  Canvas.Font.Color := HeaderColors.SysColor[COLOR_BTNTEXT];
+
+  if Focused then
+  begin
+    Canvas.Pen.Color := HeaderColors.SysColor[COLOR_HIGHLIGHT];
+    if Horizontal then
+      Canvas.Line(r.Left, r.Bottom - 1, r.Right, r.Bottom - 1)
+    else
+      Canvas.Line(r.Right - 1, r.Top, r.Right - 1, r.Bottom);
+  end;
+end;
+
+// Force DockMaster.HeaderStyle to 'MetaDark' and ensure CurrentADHeaderStyle
+// actually binds to DrawMetaDarkHeader. Handles two edge cases:
+// (1) FHeaderStyle is already 'MetaDark' but CurrentADHeaderStyle's DrawProc
+//     was not set to ours (setter's "if FHeaderStyle=AValue then Exit" early
+//     return skipped the rebind). Break the equality by switching to a
+//     different style first, then switch back.
+// (2) FHeaderStyle is not 'MetaDark' (e.g. overwritten by LoadSettings when
+//     anchordocking desktop was restored) - just switch it.
+procedure ForceApplyMetaDarkHeaderStyle;
+begin
+  if DockMaster = nil then Exit;
+  if SameText(DockMaster.HeaderStyle, MetaDarkHeaderStyleName) then
+    DockMaster.HeaderStyle := 'Frame3D';
+  DockMaster.HeaderStyle := MetaDarkHeaderStyleName;
+end;
+
+procedure RegisterMetaDarkHeaderStyle(const ASchemeColors: TDSColors);
+begin
+  HeaderColors := ASchemeColors;
+  if DockMaster = nil then Exit;
+  DockMaster.RegisterHeaderStyle(MetaDarkHeaderStyleName,
+    @DrawMetaDarkHeader, False, True);
+  ForceApplyMetaDarkHeaderStyle;
+end;
+
+procedure TMetaDarkHeaderHook.OnIDERestoreWindows(Sender: TObject);
+begin
+  // Latest reliable hook point before IDE shows windows. All options
+  // (including anchordocking desktop settings) have finished loading by now.
+  // If LoadSettings overwrote our MetaDark set during boot handler, this
+  // forces it back.
+  if IsDarkModeEnabled then
+    ForceApplyMetaDarkHeaderStyle;
+end;
+
+procedure HookIDERestoreWindows;
+begin
+  if HookInstalled then Exit;
+  if LazarusIDE = nil then Exit;
+  if Hook = nil then
+    Hook := TMetaDarkHeaderHook.Create;
+  LazarusIDE.AddHandlerOnIDERestoreWindows(@Hook.OnIDERestoreWindows);
+  HookInstalled := True;
+end;
+
+finalization
+  FreeAndNil(Hook);
+
+end.


### PR DESCRIPTION
## Summary

- Registers a new 'MetaDark' header style via AnchorDocking's
  `RegisterHeaderStyle` extension point, fixing bright dock header
  caption bars (e.g. Object Inspector) when running on a Light-themed
  host or over RDP to a Light-themed machine.
- No Lazarus source changes. Only affects `metadarkstyledsgn.lpk`.

## Problem

`TAnchorDockHeader.Draw` hard-codes `Canvas.Brush.Color := clForm` as
the background for its default styles (`Frame3D`, `Line`, `Lines`,
`Points`). The fill therefore ignores the active metadarkstyle scheme,
which is especially visible under Allow Dark with a Light system theme
or when RDP'ing to a Light-themed Windows host.

## Approach

- New `'MetaDark'` header style registered with
  `NeedDrawHeaderAfterText = false` so the DrawProc fully owns
  painting and the hard-coded `clForm` fill is bypassed.
- DrawProc uses `SysColor[COLOR_BTNFACE]` for the background,
  `SysColor[COLOR_BTNTEXT]` for caption color, and draws a thin
  `COLOR_HIGHLIGHT` line on the short edge when focused.
- Activated only when `IsDarkModeEnabled` is true; `pamForceLight`
  is unaffected.

## Why two apply points

`DockMaster.LoadSettings` runs after `libhEnvironmentOptionsLoaded`
(when `RegisterSubConfig(EnvGuiOpts, '/', True)` triggers
`ReadFromXml -> ExportSettingsToIDE`) and restores `HeaderStyle` from
the anchordocking desktop config, overwriting whatever the boot
handler had set. To stay robust:

1. Boot handler applies the style so the first paint is already dark.
2. A `lihtIDERestoreWindows` handler (installed from `Register`)
   re-applies it - the latest reliable moment before windows are
   restored.

`SetHeaderStyle`'s early-return on equality can leave
`CurrentADHeaderStyle` unbound to our DrawProc if `FHeaderStyle` is
already `'MetaDark'` from a persisted session; `ForceApplyMetaDarkHeaderStyle`
briefly switches to `'Frame3D'` first to force a real rebind.

## Files

- `src/dsgn/umetadarkheaderstyle.pas` (new) - DrawProc, registration,
  and `lihtIDERestoreWindows` hook.
- `src/dsgn/registermetadarkstyledsgn.pas` - apply in `SetDarkStyle`;
  install the IDE handler from `Register`.
- `metadarkstyledsgn.lpk` - add the new unit; add `AnchorDocking` as
  a required package.

## Scope

Only covers the IDE (metadarkstyledsgn). Third-party LCL applications
that embed AnchorDocking directly aren't handled here - happy to do a
follow-up if there's interest.

## Test plan

- [x] `lazbuild metadarkstyledsgn.lpk` compiles clean.
- [x] IDE rebuilt; dock headers (Object Inspector, etc.) are dark on
      first launch under Allow Dark / Force Dark.
- [x] Close and relaunch IDE - dock headers stay dark (this was the
      regression that motivated the `lihtIDERestoreWindows` hook).