### PR TITLE
Broadcast WM_SYSCOLORCHANGE after installing IAT hooks

### DIFF
--- a/src/uwin32widgetsetdark.pas
+++ b/src/uwin32widgetsetdark.pas
@@ -2598,6 +2598,12 @@ begin
       ReplaceImportFunction(pFunction, @_DrawEdge);
     end;
   end;
+
+  // Notify the LCL app window that system colors changed, so cached
+  // TBrush GDI handles get invalidated and re-resolved against the
+  // current (now hooked) GetSysColorBrush on next paint.
+  if Application.Handle <> 0 then
+    PostMessage(HWND(Application.Handle), WM_SYSCOLORCHANGE, 0, 0);
 end;
 
 initialization


### PR DESCRIPTION
## Summary

Fix the root cause of cached LCL TBrush handles painting with the
pre-hook (light) colors after `ApplyMetaDarkStyle` installs the
GetSysColor/GetSysColorBrush IAT hooks.

After Initialize swaps in the dark hooks, broadcast WM_SYSCOLORCHANGE
to the LCL Application window via PostMessage. LCL's Win32 widgetset
handler invalidates GraphicsUpdateCount and (with the companion LCL
MR) clears BrushResourceCache, so existing TBrush instances re-resolve
through the now-hooked GetSysColorBrush on next paint.

PostMessage (async) is used instead of SendMessage to avoid blocking on
external windows that may stall when handling the broadcast.

## Companion change

This relies on the LCL-side WM_SYSCOLORCHANGE handler that clears the
brush resource cache. See companion LCL MR (link will be added).

Discussed and agreed in https://gitlab.com/freepascal.org/lazarus/-/issues/42244.

## Test plan
- [x] MRE `examples/clform_repro/mds_hook_timing.lpr`: PaintBox A switches from light to dark on hook install
- [x] Lazarus IDE: dock header dark on startup; survives RDP disconnect/reconnect